### PR TITLE
fixed roadmap buttons color

### DIFF
--- a/app/(main)/roadmap/components/unit-button.tsx
+++ b/app/(main)/roadmap/components/unit-button.tsx
@@ -85,7 +85,7 @@ export const UnitButton = ({ id, index, totalCount, topic_name, section_id, lock
                             {locked ? (
                                 <Button
                                     size={"rounded"} 
-                                    variant="danger"
+                                    variant="locked"
                                     className="h-[70px] w-[70px] border-b-8 cursor-not-allowed"
                                     disabled
                                 >

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -28,6 +28,8 @@ const buttonVariants = cva(
                   transition-none`,
         sidebarOutline: `bg-sky-500/15 text-sky-500 border-sky-300 border-2 
                   hover:bg-sky-500/20 transition-none`,
+        locked: `bg-neutral-200 text-primary-foreground hover:bg-neutral-200/90 border-neutral-400
+                 border-b-4 active:border-b-0`,
       },
       size: {
         default: "h-11 px-4 py-2",


### PR DESCRIPTION
This pull request includes changes to the button styles in the `unit-button.tsx` and `button.tsx` files to introduce a new "locked" variant and update the locked button appearance.

Changes to button styles:

* [`app/(main)/roadmap/components/unit-button.tsx`](diffhunk://#diff-e8b09b4c8196824d1f3a14ffce07ce87368fb0ceeb72ae695b688486f1e52b97L88-R88): Changed the `variant` property of the `Button` component from "danger" to "locked" for locked buttons.
* [`components/ui/button.tsx`](diffhunk://#diff-2795b661f0806f90ae4821c33bdc2c7615156b270ec45bde4769727f4b6bc748R31-R32): Added a new "locked" variant to the `buttonVariants` object with specific styles for background color, text color, hover state, and border.